### PR TITLE
Allowed for empty actions in derived stores in order to enable just t…

### DIFF
--- a/Sources/UnidirectionalFlow/Store.swift
+++ b/Sources/UnidirectionalFlow/Store.swift
@@ -50,16 +50,18 @@ import Foundation
 
 extension Store {
     /// Use this method to create another `Store` deriving from the current one.
-    public func derived<DerivedState: Equatable, DerivedAction: Equatable>(
+    public func derived<DerivedState: Equatable, DerivedAction>(
         deriveState: @escaping (State) -> DerivedState,
-        deriveAction: @escaping (DerivedAction) -> Action
+        deriveAction: @escaping (DerivedAction) -> Action?
     ) -> Store<DerivedState, DerivedAction> {
         let derived = Store<DerivedState, DerivedAction>(
             initialState: deriveState(state),
             reducer: IdentityReducer(),
             middlewares: [
                 SendableMiddleware { _, action in
-                    await self.send(deriveAction(action))
+                    if let derivedAction = deriveAction(action) {
+                        await self.send(derivedAction)
+                    }
                     return nil
                 }
             ]

--- a/Tests/UnidirectionalFlowTests/StoreTests.swift
+++ b/Tests/UnidirectionalFlowTests/StoreTests.swift
@@ -134,11 +134,27 @@ import XCTest
         
         XCTAssertEqual(store.counter, 3)
         XCTAssertEqual(derived.counter, 3)
-        
+
         await derived.send(.decrement)
         
         XCTAssertEqual(store.counter, 2)
         XCTAssertEqual(derived.counter, 2)
+
+        let emptyAction: (Action) -> Action? = { _ in nil }
+        let derivedWithoutAction = store.derived(deriveState: { $0 }, deriveAction: emptyAction)
+
+        XCTAssertEqual(store.counter, 2)
+        XCTAssertEqual(derivedWithoutAction.counter, 2)
+
+        await derivedWithoutAction.send(.increment)
+
+        XCTAssertEqual(store.counter, 2)
+        XCTAssertEqual(derivedWithoutAction.counter, 2)
+
+        await store.send(.increment)
+
+        XCTAssertEqual(store.counter, 3)
+        XCTAssertEqual(derivedWithoutAction.counter, 3)
     }
     
     func testBinding() async {


### PR DESCRIPTION
…o connect to the state without the need to define or use any particular actions when using the derived store.